### PR TITLE
Don't send balloons to an idle browser

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,7 @@
   "manifest_version": 3,
   "name": "Pop-a-loon",
   "description": "A fun Chrome extension that lets balloons rise on your screen",
-  "permissions": [
-    "storage",
-    "alarms"
-  ],
+  "permissions": ["storage", "alarms", "idle"],
   "icons": {
     "16": "./resources/icons/icon-16.png",
     "24": "./resources/icons/icon-24.png",
@@ -15,24 +12,14 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "https://*/*",
-        "http://*/*"
-      ],
-      "js": [
-        "./content.js"
-      ]
+      "matches": ["https://*/*", "http://*/*"],
+      "js": ["./content.js"]
     }
   ],
   "web_accessible_resources": [
     {
-      "matches": [
-        "https://*/*",
-        "http://*/*"
-      ],
-      "resources": [
-        "resources/**/*"
-      ]
+      "matches": ["https://*/*", "http://*/*"],
+      "resources": ["resources/**/*"]
     }
   ],
   "background": {

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -63,7 +63,8 @@ const updateBadgeColors = () => {
     // Select a random tab
     const num = Math.round(generateRandomNumber(0, tabs.length - 1));
     const tab = tabs[num];
-    if (!tab.id) return;
+    const state = await browser.idle.queryState(5 * 60);
+    if (!tab.id || state !== 'active') return;
     console.log(`Sending spawnBalloon to`, tab);
 
     // Send the spawnBalloon message


### PR DESCRIPTION
This pr add the [`idle`](https://developer.chrome.com/docs/extensions/reference/api/idle) permission. This is required because the backround script shouldn't send balloons to the browser if it isn't active