### PR TITLE
Run backgroundscript with setTimeout #104

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -147,4 +147,5 @@ const updateBadgeColors = () => {
 
   browser.runtime.onStartup.addListener(backgroundScript);
   browser.runtime.onInstalled.addListener(backgroundScript);
+  setTimeout(backgroundScript, 500);
 })();

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -85,7 +85,10 @@ const updateBadgeColors = () => {
     await browser.alarms.create(name, { when: Date.now() + randomDelay });
   };
 
+  let backgroundScriptRunning = false;
   const backgroundScript = async () => {
+    if (backgroundScriptRunning) return;
+    backgroundScriptRunning = true;
     try {
       // If extension is being run in firefox, set the browserAction popup
       if (getBrowser() === 'Firefox' && !('action' in browser)) {


### PR DESCRIPTION
This pr add a setTimeout call to the end of the background script that waits 0.5s before running the background script. The background script didn't load correctly when disabling and re-enabling the extension.

> It also checks the background script doesn't run twice.