### PR TITLE
Disable balloon spawn in full screen videos

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -8,12 +8,14 @@ import * as Balloons from '@/balloons';
 type _initialConfig = {
   popVolume: number;
   spawnRate: number;
+  fullScreenVideoSpawn: boolean;
 } & RemoteConfig;
 
 export const initalConfig: _initialConfig = {
   // Local config
   popVolume: 70,
   spawnRate: 1,
+  fullScreenVideoSpawn: false,
 
   // Remote config -> can be overriden by the remote
   badge: {

--- a/src/content/spawn-balloon.ts
+++ b/src/content/spawn-balloon.ts
@@ -1,12 +1,24 @@
 import browser from 'webextension-polyfill';
 import * as balloons from '@/balloons';
-import { getBalloonContainer, importStylesheet, weightedRandom } from '@/utils';
+import {
+  getBalloonContainer,
+  importStylesheet,
+  isFullScreenVideoPlaying,
+  weightedRandom,
+} from '@/utils';
 import log from '@/managers/log';
 import storage from '@/managers/storage';
 
 (async () => {
   // Prevent running in popup
   if (document.body.id === 'pop-a-loon') return;
+
+  // Run checks to see if the balloon should spawn
+  if (isFullScreenVideoPlaying()) {
+    log.debug('Full screen video playing, not spawning balloon');
+    return;
+  }
+
   log.setLevel((await storage.local.get('loglevel')) || 'info');
   log.groupCollapsed('debug', 'Pop-a-loon: Spawning balloon');
   log.time('debug', 'Balloon spawn time');

--- a/src/content/spawn-balloon.ts
+++ b/src/content/spawn-balloon.ts
@@ -13,8 +13,10 @@ import storage from '@/managers/storage';
   // Prevent running in popup
   if (document.body.id === 'pop-a-loon') return;
 
+  const config = await storage.sync.get('config');
+
   // Run checks to see if the balloon should spawn
-  if (isFullScreenVideoPlaying()) {
+  if (!config.fullScreenVideoSpawn && isFullScreenVideoPlaying()) {
     log.debug('Full screen video playing, not spawning balloon');
     return;
   }

--- a/src/popup/components/forms/LocalSettings.tsx
+++ b/src/popup/components/forms/LocalSettings.tsx
@@ -18,6 +18,7 @@ import { Default as DefaultBalloon } from '@/balloons';
 import storage from '@/managers/storage';
 import log from '@/managers/log';
 import { askOriginPermissions } from '@/utils';
+import { initalConfig } from '@/const';
 
 const MIN_POP_VOLUME = 0;
 const VOLUME_STEP = 20;
@@ -37,9 +38,11 @@ const formSchema = z.object({
 });
 
 export default () => {
-  const [popVolume, setPopVolume] = useState(0);
-  const [spawnRate, setSpawnRate] = useState(0);
-  const [fullScreenVideoSpawn, setFullScreenVideoSpawn] = useState(false);
+  const [popVolume, setPopVolume] = useState(initalConfig.popVolume);
+  const [spawnRate, setSpawnRate] = useState(initalConfig.spawnRate);
+  const [fullScreenVideoSpawn, setFullScreenVideoSpawn] = useState(
+    initalConfig.fullScreenVideoSpawn
+  );
   const [permissions, setPermissions] = useState<Permissions.AnyPermissions>(
     {}
   );

--- a/src/popup/components/forms/LocalSettings.tsx
+++ b/src/popup/components/forms/LocalSettings.tsx
@@ -217,6 +217,13 @@ export default () => {
                       Weither or not to spawn balloons in fullscreen video
                       players, like youtube.
                     </p>
+                    <p className="pt-1 text-sm font-medium leading-tight text-muted-foreground">
+                      {fullScreenVideoSpawn ? (
+                        <>Balloons can spawn!</>
+                      ) : (
+                        <>Balloons will not spawn.</>
+                      )}
+                    </p>
                   </InfoIcon>
                 </span>
               </FormLabel>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,4 +159,5 @@ export const isFullScreenVideoPlaying = () => {
       return true;
     }
   }
+  return false;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,3 +139,24 @@ export async function askOriginPermissions() {
   });
   log.debug('Permissions granted for', permissions);
 }
+
+export const isFullScreenVideoPlaying = () => {
+  const fullscreenElement = document.fullscreenElement;
+  if (fullscreenElement) {
+    if (fullscreenElement.tagName.toLowerCase() === 'video') {
+      return true;
+    }
+    const videos = fullscreenElement.getElementsByTagName('video');
+    if (videos.length > 0) {
+      return true;
+    }
+  }
+
+  const videos = document.getElementsByTagName('video');
+  for (let video of videos) {
+    const rect = video.getBoundingClientRect();
+    if (rect.width === window.innerWidth) {
+      return true;
+    }
+  }
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,16 +146,11 @@ export const isFullScreenVideoPlaying = () => {
     if (fullscreenElement.tagName.toLowerCase() === 'video') {
       return true;
     }
-    const videos = fullscreenElement.getElementsByTagName('video');
+    const videos = [
+      ...fullscreenElement.getElementsByTagName('video'),
+      ...document.getElementsByTagName('video'),
+    ];
     if (videos.length > 0) {
-      return true;
-    }
-  }
-
-  const videos = document.getElementsByTagName('video');
-  for (let video of videos) {
-    const rect = video.getBoundingClientRect();
-    if (rect.width === window.innerWidth) {
       return true;
     }
   }


### PR DESCRIPTION
Add an option to enable/disable balloon spawns in full screen video players like youtube.

![image](https://github.com/user-attachments/assets/445d79cb-335b-4a81-83ae-c2542989f815)

With pop over:

![image](https://github.com/user-attachments/assets/750a03d3-79d0-497c-ac74-9e58b53e05ff)
